### PR TITLE
Add duotone neon hero header

### DIFF
--- a/public/noise.svg
+++ b/public/noise.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500">
+    <filter id="noise" x="0" y="0">
+      <feTurbulence type="fractalNoise" baseFrequency="0.65" numOctaves="3" stitchTiles="stitch"/>
+      <feBlend mode="screen"/>
+    </filter>
+    <rect width="500" height="500" filter="url(#noise)" opacity="0.5"/>
+</svg>

--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -7,24 +7,38 @@ import { Section, GradientText } from '@/components/common';
 const HeroSection = () => {
   return (
     <Section className="!pt-28 md:!pt-40 bg-cover bg-center relative" id="hero" aria-labelledby="hero-heading">
-      <div className="absolute inset-0 bg-black/60 z-0" aria-hidden="true"></div>
       <div className="absolute inset-0 z-[-1]" aria-hidden="true">
         <img
-          className="object-cover w-full h-full opacity-30"
-          alt="Abstract background representing a cultural supernova, with vibrant colors and swirling patterns."
-          src="https://images.unsplash.com/photo-1581273997534-8bce371e63c3" />
+          className="object-cover w-full h-full"
+          alt="Crowd enjoying a high-energy night festival"
+          src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1920&h=1080&q=80" />
+        <div className="absolute inset-0 bg-indigo-700 mix-blend-multiply opacity-50"></div>
+        <div className="absolute inset-0 bg-pink-600 mix-blend-screen opacity-40"></div>
+        <div className="absolute inset-0 bg-noise pointer-events-none"></div>
+        <div className="absolute inset-0 bg-black/60"></div>
       </div>
       <div className="relative z-10 text-center">
-        <motion.h1
-          id="hero-heading"
-          className="text-4xl sm:text-5xl md:text-7xl font-extrabold mb-6"
+        <motion.div
           initial={{ scale: 0.5, opacity: 0 }}
           animate={{ scale: 1, opacity: 1 }}
           transition={{ duration: 0.8, type: "spring", stiffness: 100 }}
+          className="inline-block rounded-3xl border border-white/30 bg-black/40 backdrop-blur-md px-6 py-4 mb-6"
         >
-          <GradientText>Stormfest</GradientText>
-          <span className="block text-2xl sm:text-3xl md:text-4xl mt-2 font-medium text-gray-200">The Cultural Supernova of the Century</span>
-        </motion.h1>
+          <h1
+            id="hero-heading"
+            className="neon-text text-5xl sm:text-6xl md:text-8xl font-extrabold tracking-tight uppercase"
+          >
+            STORMFEST
+          </h1>
+        </motion.div>
+        <motion.p
+          className="text-2xl sm:text-3xl md:text-4xl mt-2 font-medium text-gray-200"
+          initial={{ y: 10, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          transition={{ duration: 0.5, delay: 0.2 }}
+        >
+          The Cultural Supernova of the Century
+        </motion.p>
         <motion.div
           className="flex flex-col sm:flex-row justify-center items-center space-y-3 sm:space-y-0 sm:space-x-6 mb-8 text-md md:text-lg text-gray-200"
           initial={{ y: 20, opacity: 0 }}

--- a/src/index.css
+++ b/src/index.css
@@ -90,3 +90,6 @@
 ::-webkit-scrollbar-thumb:hover {
   background: hsl(var(--primary));
 }
+.bg-noise { background-image: url("/noise.svg"); mix-blend-mode: overlay; opacity: 0.3; }
+.neon-text { text-shadow: 0 0 10px rgba(255,255,255,0.9), 0 0 20px rgba(255,20,147,0.8), 0 0 40px rgba(255,20,147,0.7); }
+


### PR DESCRIPTION
## Summary
- update `HeroSection` with duotone festival background and noise overlay
- add neon-style header element with rounded Vision Pro-like boundary
- add CSS helpers for noise and neon text

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686a8c7d4d8483229083b92dc6b122d2